### PR TITLE
Add ability to save SVGs of plots

### DIFF
--- a/utils/mpl_plotly.py
+++ b/utils/mpl_plotly.py
@@ -90,10 +90,13 @@ class Figure(object):
         else:
             raise NotImplementedError
 
-    def show(self):
+    def show(self,save=False):
         data = self.traces
         fig = go.Figure(data = data, layout = go.Layout(**self.layout))
-        py.iplot(fig)
+        imagestr=None
++       if save:
++           imagestr='svg'
++       py.iplot(fig,image=imagestr)
 
 class Plt(object):
     def __init__(self):
@@ -150,9 +153,9 @@ class Plt(object):
     def legend(self):
         pass
 
-    def show(self):
+    def show(self,save=False):
         for fig in self.figures:
-            fig.show()
+            fig.show(save=save)
         self._clear()
 
     def imshow(self, *args, **kwargs):


### PR DESCRIPTION
added to the plt.show function with the save flag.
plt.show(save=True) will download an svg version of the image.
Not this requires a recent version of plotly. I have it working for plotly 1.12.9